### PR TITLE
ND Fixes for mixed RNDT non-working features.

### DIFF
--- a/src/main/plugin/iso19139.rndt/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.rndt/config/associated-panel/default.json
@@ -65,6 +65,7 @@
     "multilingualFields": [
       "name",
       "desc"
-    ]
+    ],
+    "rndt": true
   }
 }

--- a/src/main/plugin/iso19139.rndt/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.rndt/config/associated-panel/default.json
@@ -1,11 +1,10 @@
 {
   "config": {
-    "display": "radio",
     "types": [
       {
         "label": "addOnlinesrc",
         "sources": {
-          "filestore": true
+          "filestore": false
         },
         "icon": "fa gn-icon-onlinesrc",
         "process": "onlinesrc-add",
@@ -44,8 +43,8 @@
       {
         "label": "addThumbnail",
         "sources": {
-          "filestore": true,
-          "thumbnailMaker": true
+          "filestore": false,
+          "thumbnailMaker": false
         },
         "icon": "fa gn-icon-thumbnail",
         "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",

--- a/src/main/plugin/iso19139.rndt/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.rndt/config/associated-panel/default.json
@@ -1,0 +1,70 @@
+{
+  "config": {
+    "display": "radio",
+    "types": [
+      {
+        "label": "addOnlinesrc",
+        "sources": {
+          "filestore": true
+        },
+        "icon": "fa gn-icon-onlinesrc",
+        "process": "onlinesrc-add",
+        "fields": {
+          "protocol": {
+            "value": "Web Map Service (WMS)",
+            "isMultilingual": false,
+            "required": true,
+            "tooltip": "gmd:protocol"
+          },
+          "url": {
+            "isMultilingual": false,
+            "required": true,
+            "tooltip": "gmd:URL"
+          },
+          "name": {
+            "tooltip": "gmd:name"
+          },
+          "desc": {
+            "value": "end point",
+            "required": true,
+            "tooltip": "gmd:description"
+          },
+          "function": {
+            "isMultilingual": false,
+            "tooltip": "gmd:function"
+          },
+          "applicationProfile": {
+            "value": "Servizio di consultazione",
+            "required": true,
+            "isMultilingual": false,
+            "tooltip": "gmd:applicationProfile"
+          }
+        }
+      },
+      {
+        "label": "addThumbnail",
+        "sources": {
+          "filestore": true,
+          "thumbnailMaker": true
+        },
+        "icon": "fa gn-icon-thumbnail",
+        "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
+        "process": "thumbnail-add",
+        "fields": {
+          "url": {
+            "param": "thumbnail_url",
+            "isMultilingual": false,
+            "required": true
+          },
+          "name": {
+            "param": "thumbnail_desc"
+          }
+        }
+      }
+    ],
+    "multilingualFields": [
+      "name",
+      "desc"
+    ]
+  }
+}

--- a/src/main/plugin/iso19139.rndt/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.rndt/layout/config-editor.xml
@@ -313,6 +313,7 @@
 
       <sidePanel>
         <directive data-gn-validation-report=""/>
+        <directive data-gn-overview-manager=""/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
 

--- a/src/main/plugin/iso19139.rndt/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.rndt/process/onlinesrc-add.xsl
@@ -134,33 +134,10 @@ Insert is made in first transferOptions found.
             select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"/>
           <xsl:apply-templates
             select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor"/>
-          <gmd:transferOptions>
-            <gmd:MD_DigitalTransferOptions>
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:unitsOfDistribution"/>
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:transferSize"/>
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:onLine"/>
-
-
-              <xsl:if test="$updateKey = ''">
-                <xsl:call-template name="createOnlineSrc"/>
-              </xsl:if>
-
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:offLine"/>
-            </gmd:MD_DigitalTransferOptions>
-          </gmd:transferOptions>
-
-
           <xsl:apply-templates
-            select="gmd:distributionInfo/gmd:MD_Distribution/
-                      gmd:transferOptions[position() > 1]"/>
+            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions"/>
+
+          <xsl:call-template name="createTransferOptions"/>
 
         </gmd:MD_Distribution>
       </gmd:distributionInfo>
@@ -190,6 +167,15 @@ Insert is made in first transferOptions found.
     <xsl:call-template name="createOnlineSrc"/>
   </xsl:template>
 
+  <xsl:template name="createTransferOptions">
+    <gmd:transferOptions>
+      <gmd:MD_DigitalTransferOptions>
+        <xsl:if test="$updateKey = ''">
+          <xsl:call-template name="createOnlineSrc"/>
+        </xsl:if>
+      </gmd:MD_DigitalTransferOptions>
+    </gmd:transferOptions>
+  </xsl:template>
 
   <xsl:template name="createOnlineSrc">
     <!-- Add all online source from the target metadata to the

--- a/src/main/plugin/iso19139.rndt/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.rndt/update-fixed-info.xsl
@@ -341,6 +341,34 @@
       <xsl:apply-templates select="gmd:ISSN"/>
     </xsl:copy>
   </xsl:template>
+
+<!-- Modifica CSI [ND]: Aggiornamento URL risorse PNG -->
+    <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:graphicOverview" priority="10">
+
+        <xsl:message>=======================================</xsl:message>
+        <xsl:message>||| Processing now graphicOverviews |||</xsl:message>
+        <xsl:variable name="originalUrl" select="gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString/text()"/>
+        <xsl:message>||| Processing Original Url: <xsl:value-of select="$originalUrl"/></xsl:message>
+        <xsl:variable name="urlPrefix" select="substring-before($originalUrl, 'records/')"/>
+        <xsl:variable name="thumb_fileName" select="substring-after($originalUrl, 'attachments/')"/>
+        <xsl:variable name="thumb_newUrl" select="concat($urlPrefix,'records/',//gmd:fileIdentifier/gco:CharacterString, '/attachments/', $thumb_fileName)"/>
+        <xsl:message>||| Updated Url is: <xsl:value-of select="$thumb_newUrl"/></xsl:message>
+        <gmd:graphicOverview>
+            <gmd:MD_BrowseGraphic>
+                <gmd:fileName>
+                    <gco:CharacterString>
+                        <xsl:value-of select="$thumb_newUrl"/>
+                    </gco:CharacterString>
+                </gmd:fileName>
+
+                <xsl:apply-templates select="gmd:MD_BrowseGraphic/gmd:fileDescription|gmd:MD_BrowseGraphic/gmd:fileType"/>
+            </gmd:MD_BrowseGraphic>
+        </gmd:graphicOverview>
+        <xsl:message>||| Completed graphicOverview Processing |||</xsl:message>
+        <xsl:message>============================================</xsl:message>
+    </xsl:template>
+
+
 <!--Modifica CSI: Distinto comportamento dei servizi che non devono avere il tag gmd:series-->
 <xsl:template match="gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation" priority="10">
     <xsl:copy>


### PR DESCRIPTION
This PR fixes a set of issues identified by SR an SS:

- In the related resources panel, OGC services were not working after label update and default values + required fields were not working as expected, this is fixed in ca03199
- In case of RNDT plugin and WMS service, when selecting layers, Description field loses dropdown selected option. Fixed in geonetwork code + commit cb541ce
- RNDT plugin when adding an online resource, was adding a single onLine item inside the first existing transferOptions element, this breaks remove in the config-editor layout. Despite this being formally accepted, the correct expected result is a fully new transferOptions element. Fixed in commit 35fc922
- Thumbnails generation and firestore selection in the related resources panel has removed ad per customer request. Fixed in commit 89e3e8c
- Added the overview panel inside sidePanel, and fixed an issue when while creating the new metadata and adding a thumbnail, this did not have the "iPA" prefix in the url, making the preview and the availability of the resource broken. The update-fixed-info file has a new template fixing this in commit 7352620

To be reviewed and merged, cc to @silvia-starnini @SaraRatto 